### PR TITLE
Updated instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Thrift language binding).
     tar xzvf ./target/accumulo-proxy-2.0.0-SNAPSHOT-bin.tar.gz -C /path/to/install
     ```
 
-2. Edit `proxy.properties` and `accumulo-client.properties` and run the proxy.
+2. Edit `proxy.properties` and run the proxy.
 
     ```
     cd /path/to/install/accumulo-proxy-2.0.0-SNAPSHOT
-    ./bin/accumulo-proxy -p conf/proxy.properties -c $ACCUMULO_HOME/conf/accumulo-client.properties
+    ./bin/accumulo-proxy -p conf/proxy.properties
     ```
 
 # Build language specific bindings
@@ -60,6 +60,7 @@ Run the commands below to install the Python bindings and create an example clie
 mkdir accumulo-client/
 cd accumulo-client/
 pipenv --python 2.7
+pipenv install thrift
 pipenv install -e /path/to/accumulo-proxy/src/main/python
 cp /path/to/accumulo-proxy/src/main/python/example.py .
 # Edit credentials if needed


### PR DESCRIPTION
* The -c option is no longer exists as all accumulo-client.properties
  now reside in proxy.properties
* thrift must be installed to use Python client