### PR TITLE
Updated the maven-enforcer-plugin to 3.0.0-M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,11 @@
           <version>3.1.0</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M3</version>
+        </plugin>
+        <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
           <version>2.10.0</version>


### PR DESCRIPTION
Full details of this change and reasoning behind it is in issue https://github.com/apache/accumulo-proxy/issues/18 

I  upgraded the maven-enforcer-plugin version from 1.4.1 to 3.0.0-M3

Have verified it builds locally for me under Java 14 and packages to a tarball correctly.

Have also stood up the binary and confirmed that I can use Python against the accumulo-proxy to access a fluo-uno instantiated accumulo instance.