### PR TITLE
accumulo-proxy #22 - Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,14 @@ FROM openjdk:8
 
 EXPOSE 42424
 
-WORKDIR /opt/accumulo-proxy
-
 ARG HADOOP_VERSION=3.2.1
 ARG ZOOKEEPER_VERSION=3.5.7
 ARG ACCUMULO_VERSION=2.0.0
 ARG ACCUMULO_PROXY_VERSION=2.0.0-SNAPSHOT
 
-ARG HADOOP_HASH=a57962a24d178193349917730bf95cdc99bde9df
-ARG ZOOKEEPER_HASH=619928c8553b62775119e3d7d143a4714a160365
-ARG ACCUMULO_HASH=b72bf5c3dcaa25387933a032925046234f30e17a
+ARG HADOOP_SHA512_HASH=d62709c3d7144fcaafc60e18d0fa03d7d477cc813e45526f3646030cd87dbf010aeccf3f4ce795b57b08d2884b3a55f91fe9d74ac144992d2dfe444a4bbf34ee
+ARG ZOOKEEPER_SHA512_HASH=b9baa1ecb3d4dc0ef648ce7c74da4c5267ee89534c7614b8f27d3b0bc52004dcfbb8cecec810ffb7c8c45053daf8a5e849ce60ba241280fa1e2ab1d3b4990494
+ARG ACCUMULO_SHA512_HASH=1e2b822e0fd6ba5293b09203eb0c5cc230e9f111361634b4d5665b0ddd2b28f42d76699cb08aaeff9b3242efd5fe369bfc871a7dc361e935980889bcb7b4568f
 
 # Download from Apache mirrors instead of archive #9
 ENV APACHE_DIST_URLS \
@@ -36,43 +34,52 @@ ENV APACHE_DIST_URLS \
   https://www.apache.org/dist/ \
   https://archive.apache.org/dist/
 
+ENV HADOOP_HOME /opt/hadoop
+ENV ZOOKEEPER_HOME /opt/apache-zookeeper
+ENV ACCUMULO_HOME /opt/accumulo
+
 RUN set -eux; \
-  download_bin() { \
-    local f="$1"; shift; \
-    local hash="$1"; shift; \
-    local distFile="$1"; shift; \
+  download_verify_and_extract() { \
+    local expectedHash="$1"; \
+    local distFile="$2"; \
+    local extractPath="$3"; \
+    local symlinkPath="$4"; \
     local success=; \
     local distUrl=; \
     for distUrl in ${APACHE_DIST_URLS}; do \
-      if wget -nv -O "/tmp/${f}" "${distUrl}${distFile}"; then \
-        success=1; \
+      if wget -nv -O "/tmp/download.tar.gz" "${distUrl}${distFile}"; then \
         # Checksum the download
-        echo "${hash}" "/tmp/${f}" | sha1sum -c -; \
+        echo "${expectedHash}  /tmp/download.tar.gz" | sha512sum -c -; \
+        # Extract the download
+        mkdir "${extractPath}"; \
+        tar xzf "/tmp/download.tar.gz" -C "${extractPath}" --strip 1;\
+        # Symlink
+        ln -s "${extractPath}" "${symlinkPath}"; \
+        # Tidy up the download
+        rm -f "/tmp/download.tar.gz"; \
+        # Set success now we've done all our checks and tidied up
+        success=1; \
         break; \
       fi; \
     done; \
     [ -n "${success}" ]; \
   };\
    \
-   download_bin "apache-zookeeper.tar.gz" "${ZOOKEEPER_HASH}" "zookeeper/zookeeper-${ZOOKEEPER_VERSION}/apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz"; \
-   download_bin "hadoop.tar.gz" "$HADOOP_HASH" "hadoop/core/hadoop-${HADOOP_VERSION}/hadoop-$HADOOP_VERSION.tar.gz"; \
-   download_bin "accumulo.tar.gz" "${ACCUMULO_HASH}" "accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz";
+   download_verify_and_extract "${ZOOKEEPER_SHA512_HASH}" "zookeeper/zookeeper-${ZOOKEEPER_VERSION}/apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz" "/opt/apache-zookeeper-${ZOOKEEPER_VERSION}" "${ZOOKEEPER_HOME}"; \
+   download_verify_and_extract "${HADOOP_SHA512_HASH}" "hadoop/core/hadoop-${HADOOP_VERSION}/hadoop-$HADOOP_VERSION.tar.gz" "/opt/hadoop-${HADOOP_VERSION}" "${HADOOP_HOME}"; \
+   download_verify_and_extract "${ACCUMULO_SHA512_HASH}" "accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz" "/opt/accumulo-${ACCUMULO_VERSION}" "${ACCUMULO_HOME}" ;
 
-# Install the dependencies into /opt/
-RUN tar xzf /tmp/hadoop.tar.gz -C /opt/ && ln -s /opt/hadoop-${HADOOP_VERSION} /opt/hadoop
-RUN tar xzf /tmp/apache-zookeeper.tar.gz -C /opt/ && ln -s /opt/apache-zookeeper-${ZOOKEEPER_VERSION}-bin /opt/apache-zookeeper
-RUN tar xzf /tmp/accumulo.tar.gz -C /opt/ && ln -s /opt/accumulo-${ACCUMULO_VERSION} /opt/accumulo && sed -i 's/\${ZOOKEEPER_HOME}\/\*/\${ZOOKEEPER_HOME}\/\*\:\${ZOOKEEPER_HOME}\/lib\/\*/g' /opt/accumulo/conf/accumulo-env.sh
-
-ENV HADOOP_HOME /opt/hadoop
-ENV ZOOKEEPER_HOME /opt/apache-zookeeper
-ENV ACCUMULO_HOME /opt/accumulo
+# Fix the ZooKeeper classpath for Accumulo
+RUN sed -i 's/\${ZOOKEEPER_HOME}\/\*/\${ZOOKEEPER_HOME}\/\*\:\${ZOOKEEPER_HOME}\/lib\/\*/g' /opt/accumulo/conf/accumulo-env.sh
 
 # Add the proxy binary
-COPY target/accumulo-proxy-${ACCUMULO_PROXY_VERSION}-bin.tar.gz /tmp/
-RUN tar xzf /tmp/accumulo-proxy-${ACCUMULO_PROXY_VERSION}-bin.tar.gz -C /opt/accumulo-proxy --strip 1
 ENV ACCUMULO_PROXY_HOME /opt/accumulo-proxy
+ADD target/accumulo-proxy-${ACCUMULO_PROXY_VERSION}-bin.tar.gz /opt/
+RUN ln -s "/opt/accumulo-proxy-${ACCUMULO_PROXY_VERSION}/" "${ACCUMULO_PROXY_HOME}"
 
 # Ensure Accumulo is on the path.
 ENV PATH "${PATH}:${ACCUMULO_HOME}/bin"
+
+WORKDIR ${ACCUMULO_PROXY_HOME}
 
 CMD ["/opt/accumulo-proxy/bin/accumulo-proxy", "-p", "/opt/accumulo-proxy/conf/proxy.properties"]


### PR DESCRIPTION
Updated the Dockerfile to change some of the behavior and reduce the image size to 1.46GB from 1.86GB.

I also tried to keep the download_verify_and_extract() function readable given it now downloads the TARs, extracts them and useful symlinks in place.
I moved the HASH strings to SHA512 to match the apache.org artifacts found along side the binaries.

I've put this up early as there's some discussion on the issue https://github.com/apache/accumulo-proxy/issues/22 