### PR TITLE
Junit update to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,16 +195,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit</groupId>
-      <artifactId>junit-bom</artifactId>
-      <version>5.9.1</version>
-      <type>pom</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -362,7 +355,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M6</version>
           <configuration>
             <excludedGroups>${surefire.excludedGroups}</excludedGroups>
             <groups>${surefire.groups}</groups>
@@ -375,7 +368,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M6</version>
           <configuration>
             <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
             <groups>${failsafe.groups}</groups>

--- a/pom.xml
+++ b/pom.xml
@@ -183,12 +183,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-test</artifactId>
       <version>${accumulo.version}</version>
@@ -198,6 +192,19 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>4.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit</groupId>
+      <artifactId>junit-bom</artifactId>
+      <version>5.9.1</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -547,8 +554,12 @@
                   <property name="message" value="Use JUnit4+ @Test annotation instead of TestCase" />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="import org[.]junit[.]Assert;" />
-                  <property name="message" value="Use static imports for Assert.* methods for consistency" />
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assertions;" />
+                  <property name="message" value="Use static imports for Assertions.* methods for consistency" />
+                </module>
+                <module name="RegexpSinglelineJava">
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assumptions;" />
+                  <property name="message" value="Use static imports for Assumptions.* methods for consistency" />
                 </module>
                 <module name="OuterTypeFilename" />
                 <module name="AvoidStarImport" />

--- a/src/test/java/org/apache/accumulo/proxy/ProxyServerTest.java
+++ b/src/test/java/org/apache/accumulo/proxy/ProxyServerTest.java
@@ -17,7 +17,7 @@
 package org.apache.accumulo.proxy;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ import org.apache.accumulo.proxy.ProxyServer.BatchWriterPlusProblem;
 import org.apache.accumulo.proxy.thrift.ColumnUpdate;
 import org.apache.accumulo.proxy.thrift.WriterOptions;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/src/test/java/org/apache/accumulo/proxy/its/ProxyDurabilityIT.java
+++ b/src/test/java/org/apache/accumulo/proxy/its/ProxyDurabilityIT.java
@@ -17,8 +17,8 @@
 package org.apache.accumulo.proxy.its;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -57,7 +57,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.thrift.protocol.TJSONProtocol;
 import org.apache.thrift.server.TServer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterators;
 

--- a/src/test/java/org/apache/accumulo/proxy/its/TBinaryProxyIT.java
+++ b/src/test/java/org/apache/accumulo/proxy/its/TBinaryProxyIT.java
@@ -18,11 +18,11 @@ package org.apache.accumulo.proxy.its;
 
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.thrift.protocol.TBinaryProtocol;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TBinaryProxyIT extends SimpleProxyBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setProtocol() throws Exception {
     SharedMiniClusterBase.startMiniClusterWithConfig(new TestConfig());
     SimpleProxyBase.factory = new TBinaryProtocol.Factory();

--- a/src/test/java/org/apache/accumulo/proxy/its/TCompactProxyIT.java
+++ b/src/test/java/org/apache/accumulo/proxy/its/TCompactProxyIT.java
@@ -17,16 +17,12 @@
 package org.apache.accumulo.proxy.its;
 
 import org.apache.accumulo.harness.SharedMiniClusterBase;
-import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
-import org.apache.accumulo.test.categories.SunnyDayTests;
 import org.apache.thrift.protocol.TCompactProtocol;
-import org.junit.BeforeClass;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
 
-@Category({MiniClusterOnlyTests.class, SunnyDayTests.class})
 public class TCompactProxyIT extends SimpleProxyBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setProtocol() throws Exception {
     SharedMiniClusterBase.startMiniClusterWithConfig(new TestConfig());
     SimpleProxyBase.factory = new TCompactProtocol.Factory();

--- a/src/test/java/org/apache/accumulo/proxy/its/TJsonProtocolProxyIT.java
+++ b/src/test/java/org/apache/accumulo/proxy/its/TJsonProtocolProxyIT.java
@@ -18,11 +18,11 @@ package org.apache.accumulo.proxy.its;
 
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.thrift.protocol.TJSONProtocol;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TJsonProtocolProxyIT extends SimpleProxyBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setProtocol() throws Exception {
     SharedMiniClusterBase.startMiniClusterWithConfig(new TestConfig());
     SimpleProxyBase.factory = new TJSONProtocol.Factory();

--- a/src/test/java/org/apache/accumulo/proxy/its/TTupleProxyIT.java
+++ b/src/test/java/org/apache/accumulo/proxy/its/TTupleProxyIT.java
@@ -18,11 +18,11 @@ package org.apache.accumulo.proxy.its;
 
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.thrift.protocol.TTupleProtocol;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TTupleProxyIT extends SimpleProxyBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setProtocol() throws Exception {
     SharedMiniClusterBase.startMiniClusterWithConfig(new TestConfig());
     SimpleProxyBase.factory = new TTupleProtocol.Factory();


### PR DESCRIPTION
Closes #34 

This PR:
* updates all tests and ITs from JUnit4 to JUnit5
* updates maven surefire and failsafe versions to work with JUnit5

With these changes, the test failure described in #37 still fails. These changes also break `ProxyDurabilityIT.testDurability()` because it relies on `ConfigurableMacBase` from accumulo and the mismatch in JUnit versions between 2.0.x (using JUnit4) and JUnit5 in these changes breaks things. If this is merged, I will create a new ticket to track that test failure which I think will be fixed on it own when the project is moved to use accumulo 2.1.