### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <accumulo.version>2.0.1</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <!-- extra release args for testing -->
-    <extraReleaseArguments/>
+    <extraReleaseArguments />
     <hadoop.version>3.2.1</hadoop.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <maven.compiler.release>8</maven.compiler.release>
@@ -262,13 +262,15 @@
           <artifactId>sortpom-maven-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
-            <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
-            <lineSeparator>\n</lineSeparator>
             <expandEmptyElements>false</expandEmptyElements>
+            <keepBlankLines>false</keepBlankLines>
+            <lineSeparator>\n</lineSeparator>
             <nrOfIndentSpace>2</nrOfIndentSpace>
+            <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <sortDependencies>scope,groupId,artifactId</sortDependencies>
             <sortProperties>true</sortProperties>
+            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
             <verifyFail>Stop</verifyFail>
           </configuration>
         </plugin>
@@ -510,89 +512,89 @@
         <configuration>
           <checkstyleRules>
             <module name="Checker">
-              <property name="charset" value="UTF-8"/>
-              <property name="severity" value="warning"/>
+              <property name="charset" value="UTF-8" />
+              <property name="severity" value="warning" />
               <!-- Checks for whitespace                               -->
               <!-- See http://checkstyle.sf.net/config_whitespace.html -->
               <module name="FileTabCharacter">
-                <property name="eachLine" value="true"/>
+                <property name="eachLine" value="true" />
               </module>
               <module name="TreeWalker">
-                <module name="OneTopLevelClass"/>
+                <module name="OneTopLevelClass" />
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="\s+$"/>
-                  <property name="message" value="Line has trailing whitespace."/>
+                  <property name="format" value="\s+$" />
+                  <property name="message" value="Line has trailing whitespace." />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="[@]see\s+[{][@]link"/>
-                  <property name="message" value="Javadoc @see does not need @link: pick one or the other."/>
+                  <property name="format" value="[@]see\s+[{][@]link" />
+                  <property name="message" value="Javadoc @see does not need @link: pick one or the other." />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="jline[.]internal[.]Preconditions"/>
-                  <property name="message" value="Please use Guava Preconditions not JLine"/>
+                  <property name="format" value="jline[.]internal[.]Preconditions" />
+                  <property name="message" value="Please use Guava Preconditions not JLine" />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="org[.]apache[.]commons[.]math[.]"/>
-                  <property name="message" value="Use commons-math3 (org.apache.commons.math3.*)"/>
+                  <property name="format" value="org[.]apache[.]commons[.]math[.]" />
+                  <property name="message" value="Use commons-math3 (org.apache.commons.math3.*)" />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="junit[.]framework[.]TestCase"/>
-                  <property name="message" value="Use JUnit4+ @Test annotation instead of TestCase"/>
+                  <property name="format" value="junit[.]framework[.]TestCase" />
+                  <property name="message" value="Use JUnit4+ @Test annotation instead of TestCase" />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assertions;"/>
-                  <property name="message" value="Use static imports for Assertions.* methods for consistency"/>
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assertions;" />
+                  <property name="message" value="Use static imports for Assertions.* methods for consistency" />
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assumptions;"/>
-                  <property name="message" value="Use static imports for Assumptions.* methods for consistency"/>
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assumptions;" />
+                  <property name="message" value="Use static imports for Assumptions.* methods for consistency" />
                 </module>
-                <module name="OuterTypeFilename"/>
-                <module name="AvoidStarImport"/>
+                <module name="OuterTypeFilename" />
+                <module name="AvoidStarImport" />
                 <module name="UnusedImports">
-                  <property name="processJavadoc" value="true"/>
+                  <property name="processJavadoc" value="true" />
                 </module>
-                <module name="NoLineWrap"/>
-                <module name="LeftCurly"/>
+                <module name="NoLineWrap" />
+                <module name="LeftCurly" />
                 <module name="RightCurly">
-                  <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+                  <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT" />
                 </module>
                 <module name="SeparatorWrap">
-                  <property name="tokens" value="DOT"/>
-                  <property name="option" value="nl"/>
+                  <property name="tokens" value="DOT" />
+                  <property name="option" value="nl" />
                 </module>
                 <module name="SeparatorWrap">
-                  <property name="tokens" value="COMMA"/>
-                  <property name="option" value="EOL"/>
+                  <property name="tokens" value="COMMA" />
+                  <property name="option" value="EOL" />
                 </module>
                 <module name="PackageName">
-                  <property name="format" value="^[a-z]+(\.[a-z][a-zA-Z0-9]*)*$"/>
+                  <property name="format" value="^[a-z]+(\.[a-z][a-zA-Z0-9]*)*$" />
                 </module>
                 <module name="MethodTypeParameterName">
-                  <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+                  <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
                 </module>
-                <module name="MethodParamPad"/>
+                <module name="MethodParamPad" />
                 <module name="OperatorWrap">
-                  <property name="option" value="NL"/>
-                  <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, QUESTION, SL, SR, STAR "/>
+                  <property name="option" value="NL" />
+                  <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, QUESTION, SL, SR, STAR " />
                 </module>
                 <module name="AnnotationLocation">
-                  <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+                  <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF" />
                 </module>
                 <module name="AnnotationLocation">
-                  <property name="tokens" value="VARIABLE_DEF"/>
-                  <property name="allowSamelineMultipleAnnotations" value="true"/>
+                  <property name="tokens" value="VARIABLE_DEF" />
+                  <property name="allowSamelineMultipleAnnotations" value="true" />
                 </module>
-                <module name="NonEmptyAtclauseDescription"/>
-                <module name="JavadocTagContinuationIndentation"/>
+                <module name="NonEmptyAtclauseDescription" />
+                <module name="JavadocTagContinuationIndentation" />
                 <module name="JavadocMethod">
-                  <property name="allowMissingParamTags" value="true"/>
-                  <property name="allowMissingReturnTag" value="true"/>
-                  <property name="allowedAnnotations" value="Override,Test,BeforeClass,AfterClass,Before,After"/>
+                  <property name="allowMissingParamTags" value="true" />
+                  <property name="allowMissingReturnTag" value="true" />
+                  <property name="allowedAnnotations" value="Override,Test,BeforeClass,AfterClass,Before,After" />
                 </module>
-                <module name="SingleLineJavadoc"/>
-                <module name="MissingOverrideCheck"/>
-                <module name="AnnotationLocation"/>
+                <module name="SingleLineJavadoc" />
+                <module name="MissingOverrideCheck" />
+                <module name="AnnotationLocation" />
               </module>
             </module>
           </checkstyleRules>
@@ -745,7 +747,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -758,7 +760,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -771,7 +773,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -784,7 +786,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -798,7 +800,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -811,7 +813,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                   </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>27</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-proxy</artifactId>
@@ -88,13 +88,13 @@
     <accumulo.version>2.0.1</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <!-- extra release args for testing -->
-    <extraReleaseArguments />
+    <extraReleaseArguments/>
     <hadoop.version>3.2.1</hadoop.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <slf4j.version>1.7.30</slf4j.version>
+    <slf4j.version>2.0.3</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <spotbugs.excludeFilterFile>src/main/spotbugs/exclude-filter.xml</spotbugs.excludeFilterFile>
     <thrift.version>0.12.0</thrift.version>
@@ -103,25 +103,25 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.78</version>
+      <version>1.82</version>
     </dependency>
     <!-- spotbugs-annotations provides SuppressFBWarnings annotation -->
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.0.0</version>
+      <version>4.7.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
-      <version>1.0-rc6</version>
+      <version>1.0.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.11.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>4.2</version>
+      <version>5.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -214,12 +214,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.12.0</version>
         </plugin>
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>1.8.0</version>
+          <version>2.4.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
@@ -227,7 +227,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>3.1.12.1</version>
+          <version>4.7.2.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -251,17 +251,16 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.10.0</version>
+          <version>3.2.0</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -276,7 +275,7 @@
         <plugin>
           <groupId>com.github.koraktor</groupId>
           <artifactId>mavanagaiata</artifactId>
-          <version>0.9.4</version>
+          <version>1.0.0</version>
           <configuration>
             <skipNoGit>true</skipNoGit>
           </configuration>
@@ -284,7 +283,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
           <configuration>
             <filesets>
               <fileset>
@@ -300,7 +298,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
           <configuration>
             <optimize>true</optimize>
             <showDeprecation>true</showDeprecation>
@@ -316,7 +313,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.2</version>
           <configuration>
             <archive>
               <manifestEntries>
@@ -329,7 +325,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.1.1</version>
           <configuration>
             <quiet>true</quiet>
             <additionalJOption>-J-Xmx512m</additionalJOption>
@@ -339,7 +334,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
           <configuration>
             <arguments>-P !autoformat,thrift,sunny -Dtimeout.factor=2 ${extraReleaseArguments}</arguments>
             <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -380,12 +374,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>
@@ -395,7 +389,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.11.0</version>
+          <version>2.21.0</version>
           <configuration>
             <configFile>${eclipseFormatterStyle}</configFile>
             <compilerCompliance>${maven.compiler.source}</compilerCompliance>
@@ -417,7 +411,6 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.13</version>
           <configuration>
             <excludes>
               <exclude>src/main/resources/META-INF/services/*</exclude>
@@ -427,7 +420,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.3.2</version>
+          <version>1.7.0</version>
           <configuration>
             <removeUnused>true</removeUnused>
             <groups>java.,javax.,org.,com.</groups>
@@ -517,89 +510,89 @@
         <configuration>
           <checkstyleRules>
             <module name="Checker">
-              <property name="charset" value="UTF-8" />
-              <property name="severity" value="warning" />
+              <property name="charset" value="UTF-8"/>
+              <property name="severity" value="warning"/>
               <!-- Checks for whitespace                               -->
               <!-- See http://checkstyle.sf.net/config_whitespace.html -->
               <module name="FileTabCharacter">
-                <property name="eachLine" value="true" />
+                <property name="eachLine" value="true"/>
               </module>
               <module name="TreeWalker">
-                <module name="OneTopLevelClass" />
+                <module name="OneTopLevelClass"/>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="\s+$" />
-                  <property name="message" value="Line has trailing whitespace." />
+                  <property name="format" value="\s+$"/>
+                  <property name="message" value="Line has trailing whitespace."/>
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="[@]see\s+[{][@]link" />
-                  <property name="message" value="Javadoc @see does not need @link: pick one or the other." />
+                  <property name="format" value="[@]see\s+[{][@]link"/>
+                  <property name="message" value="Javadoc @see does not need @link: pick one or the other."/>
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="jline[.]internal[.]Preconditions" />
-                  <property name="message" value="Please use Guava Preconditions not JLine" />
+                  <property name="format" value="jline[.]internal[.]Preconditions"/>
+                  <property name="message" value="Please use Guava Preconditions not JLine"/>
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="org[.]apache[.]commons[.]math[.]" />
-                  <property name="message" value="Use commons-math3 (org.apache.commons.math3.*)" />
+                  <property name="format" value="org[.]apache[.]commons[.]math[.]"/>
+                  <property name="message" value="Use commons-math3 (org.apache.commons.math3.*)"/>
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="junit[.]framework[.]TestCase" />
-                  <property name="message" value="Use JUnit4+ @Test annotation instead of TestCase" />
+                  <property name="format" value="junit[.]framework[.]TestCase"/>
+                  <property name="message" value="Use JUnit4+ @Test annotation instead of TestCase"/>
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assertions;" />
-                  <property name="message" value="Use static imports for Assertions.* methods for consistency" />
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assertions;"/>
+                  <property name="message" value="Use static imports for Assertions.* methods for consistency"/>
                 </module>
                 <module name="RegexpSinglelineJava">
-                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assumptions;" />
-                  <property name="message" value="Use static imports for Assumptions.* methods for consistency" />
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assumptions;"/>
+                  <property name="message" value="Use static imports for Assumptions.* methods for consistency"/>
                 </module>
-                <module name="OuterTypeFilename" />
-                <module name="AvoidStarImport" />
+                <module name="OuterTypeFilename"/>
+                <module name="AvoidStarImport"/>
                 <module name="UnusedImports">
-                  <property name="processJavadoc" value="true" />
+                  <property name="processJavadoc" value="true"/>
                 </module>
-                <module name="NoLineWrap" />
-                <module name="LeftCurly" />
+                <module name="NoLineWrap"/>
+                <module name="LeftCurly"/>
                 <module name="RightCurly">
-                  <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT" />
+                  <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
                 </module>
                 <module name="SeparatorWrap">
-                  <property name="tokens" value="DOT" />
-                  <property name="option" value="nl" />
+                  <property name="tokens" value="DOT"/>
+                  <property name="option" value="nl"/>
                 </module>
                 <module name="SeparatorWrap">
-                  <property name="tokens" value="COMMA" />
-                  <property name="option" value="EOL" />
+                  <property name="tokens" value="COMMA"/>
+                  <property name="option" value="EOL"/>
                 </module>
                 <module name="PackageName">
-                  <property name="format" value="^[a-z]+(\.[a-z][a-zA-Z0-9]*)*$" />
+                  <property name="format" value="^[a-z]+(\.[a-z][a-zA-Z0-9]*)*$"/>
                 </module>
                 <module name="MethodTypeParameterName">
-                  <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+                  <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
                 </module>
-                <module name="MethodParamPad" />
+                <module name="MethodParamPad"/>
                 <module name="OperatorWrap">
-                  <property name="option" value="NL" />
-                  <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, QUESTION, SL, SR, STAR " />
+                  <property name="option" value="NL"/>
+                  <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, QUESTION, SL, SR, STAR "/>
                 </module>
                 <module name="AnnotationLocation">
-                  <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF" />
+                  <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
                 </module>
                 <module name="AnnotationLocation">
-                  <property name="tokens" value="VARIABLE_DEF" />
-                  <property name="allowSamelineMultipleAnnotations" value="true" />
+                  <property name="tokens" value="VARIABLE_DEF"/>
+                  <property name="allowSamelineMultipleAnnotations" value="true"/>
                 </module>
-                <module name="NonEmptyAtclauseDescription" />
-                <module name="JavadocTagContinuationIndentation" />
+                <module name="NonEmptyAtclauseDescription"/>
+                <module name="JavadocTagContinuationIndentation"/>
                 <module name="JavadocMethod">
-                  <property name="allowMissingParamTags" value="true" />
-                  <property name="allowMissingReturnTag" value="true" />
-                  <property name="allowedAnnotations" value="Override,Test,BeforeClass,AfterClass,Before,After" />
+                  <property name="allowMissingParamTags" value="true"/>
+                  <property name="allowMissingReturnTag" value="true"/>
+                  <property name="allowedAnnotations" value="Override,Test,BeforeClass,AfterClass,Before,After"/>
                 </module>
-                <module name="SingleLineJavadoc" />
-                <module name="MissingOverrideCheck" />
-                <module name="AnnotationLocation" />
+                <module name="SingleLineJavadoc"/>
+                <module name="MissingOverrideCheck"/>
+                <module name="AnnotationLocation"/>
               </module>
             </module>
           </checkstyleRules>
@@ -611,7 +604,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.29</version>
+            <version>10.4</version>
           </dependency>
         </dependencies>
         <executions>
@@ -752,7 +745,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore />
+                        <ignore/>
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -765,7 +758,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore />
+                        <ignore/>
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -778,7 +771,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore />
+                        <ignore/>
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -791,7 +784,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore />
+                        <ignore/>
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -805,7 +798,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore />
+                        <ignore/>
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -818,7 +811,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore />
+                        <ignore/>
                       </action>
                     </pluginExecution>
                   </pluginExecutions>


### PR DESCRIPTION
This PR updates the version for several dependencies and plugins. Also, the versions of some dependencies were removed so they could be handled by the parent pom instead. The formatting changes which removed a space before the `/>` was automated.  All tests that were passing before these changes still pass now.