### PR TITLE
Update command to run ruby example file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ vim Gemfile # Set correct path
 cp /path/to/accumulo-proxy/src/main/ruby/client.rb .
 gem install bundler
 bundle install
-bundle exec client.rb
+bundle exec ruby client.rb
 ```
 
 # Java clients to Proxy


### PR DESCRIPTION
Fixes #49 

This is the command that I had to run to get the ruby file to run. Not too familiar with ruby so I'm not sure if this is dependent on my ruby version specifically or not. The version I have installed is: `ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]`