### PR TITLE
Add python generated files to be excluded from rat check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,7 @@
           <configuration>
             <excludes>
               <exclude>src/main/resources/META-INF/services/*</exclude>
+              <exclude>src/main/python/AccumuloProxy.egg-info/*</exclude>
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
This directory, `src/main/python/AccumuloProxy.egg-info/`, is generated automatically when I run through the steps to set up the test client for python. It is already in the gitignore but it fails the rat check step of the build if I do not manually delete it. The changes in this PR make it so that the files within this directory are ignored by rat check which will not fail the build if it is present.