### PR TITLE
Fix spotbugs errors

### DIFF
--- a/src/main/java/org/apache/accumulo/proxy/Proxy.java
+++ b/src/main/java/org/apache/accumulo/proxy/Proxy.java
@@ -29,7 +29,6 @@ import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.clientImpl.ClientConfConverter;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -186,10 +185,6 @@ public class Proxy implements KeywordExecutable {
         .parseInt(props.getProperty(THRIFT_THREAD_POOL_SIZE_KEY, THRIFT_THREAD_POOL_SIZE_DEFAULT));
     final long maxFrameSize = ConfigurationTypeHelper.getFixedMemoryAsBytes(
         props.getProperty(THRIFT_MAX_FRAME_SIZE_KEY, THRIFT_MAX_FRAME_SIZE_DEFAULT));
-    final int simpleTimerThreadpoolSize = Integer
-        .parseInt(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE.getDefaultValue());
-    // How frequently to try to resize the thread pool
-    final long threadpoolResizeInterval = 1000L * 5;
     // No timeout
     final long serverSocketTimeout = 0L;
     // Use the new hadoop metrics2 support

--- a/src/test/java/org/apache/accumulo/proxy/its/SimpleProxyBase.java
+++ b/src/test/java/org/apache/accumulo/proxy/its/SimpleProxyBase.java
@@ -162,13 +162,13 @@ public abstract class SimpleProxyBase extends SharedMiniClusterBase {
   private static int proxyPort;
 
   private TestProxyClient proxyClient;
-  private static org.apache.accumulo.proxy.thrift.AccumuloProxy.Client client;
+  private org.apache.accumulo.proxy.thrift.AccumuloProxy.Client client;
 
   private static Map<String,String> properties = new HashMap<>();
   private static String hostname, proxyPrincipal, proxyPrimary, clientPrincipal;
   private static File proxyKeytab, clientKeytab;
 
-  private static ByteBuffer creds = null;
+  private ByteBuffer creds = null;
 
   // Implementations can set this
   static TProtocolFactory factory = null;


### PR DESCRIPTION
This PR fixes all spotbugs errors currently present.

Before these changes the following errors were present:

<details>
<summary>errors</summary>

```
[ERROR] Medium: Dead store to simpleTimerThreadpoolSize in org.apache.accumulo.proxy.Proxy.createProxyServer(HostAndPort, TProtocolFactory, Properties) [org.apache.accumulo.proxy.Proxy] At Proxy.java:[line 190] DLS_DEAD_LOCAL_STORE
[ERROR] Medium: Write to static field org.apache.accumulo.proxy.its.SimpleProxyBase.client from instance method org.apache.accumulo.proxy.its.SimpleProxyBase.namespacePermissions() [org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase] At SimpleProxyBase.java:[line 1677]Another occurrence at SimpleProxyBase.java:[line 1694]Another occurrence at SimpleProxyBase.java:[line 1709]Another occurrence at SimpleProxyBase.java:[line 1715]Another occurrence at SimpleProxyBase.java:[line 1728]Another occurrence at SimpleProxyBase.java:[line 1736]Another occurrence at SimpleProxyBase.java:[line 1748] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field org.apache.accumulo.proxy.its.SimpleProxyBase.client from instance method org.apache.accumulo.proxy.its.SimpleProxyBase.setup(TestInfo) [org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase] At SimpleProxyBase.java:[line 294]Another occurrence at SimpleProxyBase.java:[line 322] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field org.apache.accumulo.proxy.its.SimpleProxyBase.creds from instance method org.apache.accumulo.proxy.its.SimpleProxyBase.setup(TestInfo) [org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase] At SimpleProxyBase.java:[line 295]Another occurrence at SimpleProxyBase.java:[line 323] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field org.apache.accumulo.proxy.its.SimpleProxyBase.client from instance method org.apache.accumulo.proxy.its.SimpleProxyBase.testConditionalWriter() [org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase] At SimpleProxyBase.java:[line 2510]Another occurrence at SimpleProxyBase.java:[line 2541]Another occurrence at SimpleProxyBase.java:[line 2553]Another occurrence at SimpleProxyBase.java:[line 2572]Another occurrence at SimpleProxyBase.java:[line 2585]Another occurrence at SimpleProxyBase.java:[line 2602]Another occurrence at SimpleProxyBase.java:[line 2614]Another occurrence at SimpleProxyBase.java:[line 2629] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field org.apache.accumulo.proxy.its.SimpleProxyBase.client from instance method org.apache.accumulo.proxy.its.SimpleProxyBase.userPermissions() [org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase, org.apache.accumulo.proxy.its.SimpleProxyBase] At SimpleProxyBase.java:[line 1516]Another occurrence at SimpleProxyBase.java:[line 1533]Another occurrence at SimpleProxyBase.java:[line 1545]Another occurrence at SimpleProxyBase.java:[line 1551]Another occurrence at SimpleProxyBase.java:[line 1562]Another occurrence at SimpleProxyBase.java:[line 1570]Another occurrence at SimpleProxyBase.java:[line 1579]Another occurrence at SimpleProxyBase.java:[line 1591]Another occurrence at SimpleProxyBase.java:[line 1603]Another occurrence at SimpleProxyBase.java:[line 1615]Another occurrence at SimpleProxyBase.java:[line 1625]Another occurrence at SimpleProxyBase.java:[line 1637]Another occurrence at SimpleProxyBase.java:[line 1648] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: org.apache.accumulo.proxy.its.TestProxyClient.proxy() may expose internal representation by returning TestProxyClient.proxy [org.apache.accumulo.proxy.its.TestProxyClient] At TestProxyClient.java:[line 95] EI_EXPOSE_REP
```

</details>

The main change that needs review is the change in `TestProxyClient.java`. These changes return a new `AccumuloProxy.Client` object for each call to `proxy()`. This was done to avoid the following error:

```
[ERROR] Medium: org.apache.accumulo.proxy.its.TestProxyClient.proxy() may expose internal representation by returning TestProxyClient.proxy [org.apache.accumulo.proxy.its.TestProxyClient] At TestProxyClient.java:[line 95]
```

This change seems fine to me but I wouldn't be surprised if there is something I am overlooking that would make it so that this is not something we want to do. This is the only way I could find to fix this error.