### PR TITLE
Fix ruby and python example clients

### DIFF
--- a/src/main/assemble/conf/proxy.properties
+++ b/src/main/assemble/conf/proxy.properties
@@ -19,6 +19,7 @@
 
 # Port to run proxy on
 port=42424
+sharedSecret=sharedSecret
 # Set to true if you wish to use an Mini Accumulo Cluster
 useMiniAccumulo=false
 protocolFactory=org.apache.thrift.protocol.TCompactProtocol$Factory

--- a/src/main/python/basic_client.py
+++ b/src/main/python/basic_client.py
@@ -31,7 +31,7 @@ protocol = TCompactProtocol.TCompactProtocol(transport)
 client = AccumuloProxy.Client(protocol)
 transport.open()
 
-login = client.login('root', {'password':'secret'})
+login = "sharedSecret"
 
 print client.listTables(login)
 

--- a/src/main/ruby/client.rb
+++ b/src/main/ruby/client.rb
@@ -29,8 +29,7 @@ proxy = Accumulo::AccumuloProxy::Client.new(proto)
 # open up the connect
 transport.open()
 
-# Test if the server is up
-login = proxy.login('root', {'password' => 'secret'})
+login = "sharedSecret"
 
 # print out a table list
 puts "List of tables: #{proxy.listTables(login).inspect}"


### PR DESCRIPTION
Fixes #66 

The proxy now looks for the property `sharedSecret` in the props file. Also, the changes in #59 removed the login method.

This PR fixes these two problems.