### PR TITLE
Make sure sharedSecret is set in ProxyServer

### DIFF
--- a/src/main/java/org/apache/accumulo/proxy/ProxyServer.java
+++ b/src/main/java/org/apache/accumulo/proxy/ProxyServer.java
@@ -205,6 +205,9 @@ public class ProxyServer implements AccumuloProxy.Iface {
     }
 
     sharedSecret = props.getProperty("sharedSecret");
+    if (sharedSecret == null) {
+      throw new RuntimeException("The properties do not contain sharedSecret");
+    }
 
     serverType = tempServerType;
 


### PR DESCRIPTION
If the `sharedSecret` is not set in the properties, then the `sharedSecret` variable in ProxyServer will be null making it so that all calls to the ProxyServer will fail.

This PR makes it so that the proxy will not start unless the `sharedSecret` is not null.