### PR TITLE
Removes the include for slf4j-log4j12

### DIFF
--- a/src/main/assemble/component.xml
+++ b/src/main/assemble/component.xml
@@ -37,7 +37,6 @@
         <include>commons-lang:commons-lang</include>
         <include>org.apache.thrift:libthrift</include>
         <include>org.slf4j:slf4j-api</include>
-        <include>org.slf4j:slf4j-log4j12</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
Artifact is no longer present during build process. 